### PR TITLE
M31298: Removing extra word "and"

### DIFF
--- a/azure-go-sdk-conceptual/azure-sdk-go-tools.md
+++ b/azure-go-sdk-conceptual/azure-sdk-go-tools.md
@@ -42,7 +42,7 @@ deploy and test directly on Azure.
 
 ## Dependency management with dep
 
-The Azure SDK for Go uses dep for dependency management. The dep command allows you to pull and vendor requirements for your Go application,
+The Azure SDK for Go uses dep for dependency management. The dep command allows you to pull vendor requirements for your Go application,
  avoiding version conflicts and ensuring that your project works correctly.
 
 > [!div class="nextstepaction"]


### PR DESCRIPTION
Hello, @sptramer,
Translator has reported possible source content issue. 
Description: "and" seems to be unnecessary and translator ignored it in the target text.

Please review and merge the suggested proposed file change to avoid this error. If you make related fix in another PR, then share your PR number, so we can confirm and close this PR.
Many thanks in advance.